### PR TITLE
[Feature] - Running Kubeflow and MLFLow code through "One-Click" approach

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,6 +31,7 @@ func runCommand() *cobra.Command {
 			sTarget, _ := cmd.Flags().GetString("target")
 			sBackend, _ := cmd.Flags().GetString("backend")
 			sSource, _ := cmd.Flags().GetString("source")
+			sEntry, _ := cmd.Flags().GetString("entrypoint")
 			if len(args) == 0 && sConf == "" && sTarget == "" && sBackend == "" && sSource == "" && sExtras == "" {
 				err := cmd.Help()
 				if err != nil {
@@ -67,7 +68,7 @@ func runCommand() *cobra.Command {
 			color.InProgress()
 			fmt.Println("🧪	Initializing code...")
 			time.Sleep(700 * time.Millisecond)
-			err := runner.Loader(sSource, sTarget, sBackend, sExtras)
+			err := runner.Loader(sSource, sTarget, sBackend, sExtras, sEntry)
 			if err != nil {
 				log.Println("An error occurred, please retry and if persist, please open an issue on our GitHub repository.")
 			}
@@ -89,7 +90,8 @@ func runCommand() *cobra.Command {
 	flags.StringVarP(&run.Source, "source", "s", "", "Source code to execute. Can be YAML,Python,Jupyter Notebooks as extension.")
 	flags.StringVarP(&run.Backend, "backend", "b", "", "Backend for the code to be run. Can be: Kubeflow,Argo,MLFlow.")
 	flags.StringVarP(&run.Target, "target", "t", "", "Where the run need to be executed, it's the name of a registered cluster.")
-	flags.StringVarP(&run.Extras, "extras", "e", "", "This is equivalent of requirements.txt, it is useful to install extra packages.")
+	flags.StringVarP(&run.Extras, "extras", "x", "", "This is equivalent of requirements.txt, it is useful to install extra packages.")
+	flags.StringVarP(&run.Entrypoint, "entrypoint", "e", "", "This is the entrypoint for KFP pipelines [ -e pipeline.py].")
 	flags.BoolVarP(&run.Quiet, "quiet", "q", false, "Suppress output messages. Useful when k3ai is used within scripts.")
 	flags.StringVarP(&run.Config, "config", "c", "", "Configure K3ai using a custom config file.[-c /path/tofile] [-c https://urlToFile]")
 	return runCmd

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -73,6 +73,7 @@ func runCommand() *cobra.Command {
 				log.Println("An error occurred, please retry and if persist, please open an issue on our GitHub repository.")
 			}
 			if !bQuiet {
+				log.Println("")
 				msg := "Completing execution..."
 				loader.SuperLoader(msg)
 			} else {

--- a/internal/variables.go
+++ b/internal/variables.go
@@ -6,21 +6,22 @@ var (
 )
 
 type Options struct {
-	Quiet    bool
-	PAT      string
-	Config   string
-	All      bool
-	Force    bool
-	Deploy   bool
-	Remove   bool
-	Name     string
-	Type     string
-	Target   string
-	Filter   string
-	Deployed bool
-	Source   string
-	Backend  string
-	Extras   string
+	Quiet      bool
+	PAT        string
+	Config     string
+	All        bool
+	Force      bool
+	Deploy     bool
+	Remove     bool
+	Name       string
+	Type       string
+	Target     string
+	Filter     string
+	Deployed   bool
+	Source     string
+	Backend    string
+	Extras     string
+	Entrypoint string
 }
 
 type Env struct {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -268,7 +268,7 @@ func ListClustersByName() (clusterResults []string) {
 	return clusterResults
 }
 
-func ListClusterByName(target string) (name string, ctype string) {
+func ListClusterByName(target string) (clusterResults []string) {
 
 	db := DbLogin()
 	row, err := db.Query("SELECT name,ctype from CLUSTERS WHERE name=?;", target)
@@ -276,13 +276,16 @@ func ListClusterByName(target string) (name string, ctype string) {
 		log.Fatal(err)
 	}
 	defer row.Close()
-	row.Next()
+	for row.Next() {
+	var name string
+	var ctype string
 	err = row.Scan(&name, &ctype)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	return name, ctype
+	clusterResults = append(clusterResults, name, ctype)
+	}
+	return clusterResults
 }
 
 func CheckClusterName(name string) (resname string, ctype string) {

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: k3ai
-        image: ghcr.io/k3ai/k3ai-executor:latest
+        image: ghcr.io/k3ai/k3ai-executor:dev
         command: ["/bin/sleep", "3650d"]
 EOF
 `
@@ -50,8 +50,8 @@ func Loader(source string, target string, backend string, extras string, entrypo
 EOF
 `
 
-	name, ctype := db.ListClusterByName(target)
-	out := factory.Client(name, ctype)
+	clusterResults := db.ListClusterByName(target)
+	out := factory.Client(clusterResults[0],clusterResults[1])
 	home, _ := os.UserHomeDir()
 	shellPath := home + "/.k3ai"
 	outcome, err := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+" apply  --kubeconfig="+out+" -f - "+template).Output()
@@ -70,7 +70,7 @@ EOF
 	if backend == "mlflow" {
 		err := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"")
 		if err != nil {
-			log.Println(err)
+			log.Println(" ")
 		}
 	}
 	_, err = exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: k3ai
-        image: ghcr.io/k3ai/k3ai-executor:dev
+        image: ghcr.io/k3ai/k3ai-executor:latest
         command: ["/bin/sleep", "3650d"]
 EOF
 `
@@ -70,10 +70,10 @@ EOF
 	if backend == "mlflow" {
 		_, err := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"").Output()
 		if err != nil {
-		log.Println(err)
+			log.Println(err)
+		}
 	}
-	}
-	_,err = exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
+	_, err = exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
 	if err != nil {
 		log.Println(err)
 	}

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -68,7 +68,7 @@ EOF
 	time.Sleep(10 * time.Second)
 
 	if backend == "mlflow" {
-		_, err := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"").Output()
+		err := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"")
 		if err != nil {
 			log.Println(err)
 		}

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -59,7 +59,10 @@ EOF
 		log.Println(err)
 	}
 
-	exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
+	_, err = exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
+	if err != nil {
+		log.Println(err)
+	}
 	fmt.Println(string(outcome))
 
 	time.Sleep(10 * time.Second)
@@ -67,7 +70,10 @@ EOF
 	if backend == "mlflow" {
 		exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"").Output()
 	}
-	exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
+	_,err = exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
+	if err != nil {
+		log.Println(err)
+	}
 
 	if backend == "mlflow" {
 		cmd := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  deployment/k3ai-executor -- bash -c "+execTemplate)

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -68,7 +68,10 @@ EOF
 	time.Sleep(10 * time.Second)
 
 	if backend == "mlflow" {
-		exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"").Output()
+		_, err := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"").Output()
+		if err != nil {
+		log.Println(err)
+	}
 	}
 	_,err = exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
 	if err != nil {

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -38,16 +38,15 @@ EOF
 `
 var k3aiKube = "/.tools/kubectl"
 
-
-func Loader(source string,target string,backend string, extras string, entrypoint string) error {
+func Loader(source string, target string, backend string, extras string, entrypoint string) error {
 	var execTemplate string
-if entrypoint == "" {
-	execTemplate ="\"/opt/k3ai-executor -b " + backend + " -s " + source  + "\" "
-	execTemplate = execTemplate+ "\nEOF"
-}
+	if entrypoint == "" {
+		execTemplate = "\"/opt/k3ai-executor -b " + backend + " -s " + source + "\" "
+		execTemplate = execTemplate + "\nEOF"
+	}
 
-var execTemplateKfp ="\"/opt/k3ai-executor -b " + backend + " -s " + source  + " -e " + entrypoint + "\" "
-execTemplateKfp = execTemplateKfp + `
+	var execTemplateKfp = "\"/opt/k3ai-executor -b " + backend + " -s " + source + " -e " + entrypoint + "\" "
+	execTemplateKfp = execTemplateKfp + `
 EOF
 `
 
@@ -55,21 +54,20 @@ EOF
 	out := factory.Client(name, ctype)
 	home, _ := os.UserHomeDir()
 	shellPath := home + "/.k3ai"
-  outcome,err := exec.Command("/bin/bash","-c", "cat <<EOF | " + shellPath + k3aiKube + " apply  --kubeconfig="+ out +" -f - " + template ).Output()
-  if err != nil {
-    log.Println(err)
-  }
+	outcome, err := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+" apply  --kubeconfig="+out+" -f - "+template).Output()
+	if err != nil {
+		log.Println(err)
+	}
 
-  exec.Command("/bin/bash","-c", shellPath + k3aiKube + " wait --for=condition=Ready pods --all -n default  --kubeconfig="+ out).Output()
-  fmt.Println(string(outcome))
+	exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
+	fmt.Println(string(outcome))
 
-  time.Sleep(10 * time.Second)
-  
-  if backend == "mlflow" {
-	exec.Command("/bin/bash","-c",  "cat <<EOF | " + shellPath + k3aiKube + "  --kubeconfig="+ out + " exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"" ).Output()
-  }
-  exec.Command("/bin/bash","-c", shellPath + k3aiKube + " wait --for=condition=Ready pods --all -n default  --kubeconfig="+ out).Output()
+	time.Sleep(10 * time.Second)
 
+	if backend == "mlflow" {
+		exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"").Output()
+	}
+	exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all -n default  --kubeconfig="+out).Output()
 
 	if backend == "mlflow" {
 		cmd := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  deployment/k3ai-executor -- bash -c "+execTemplate)
@@ -99,28 +97,28 @@ EOF
 		// Start the command and check for errors
 		err := cmd.Start()
 		if err != nil {
-			log.Println("Something went wrong... did you check all the prerequisites to run this plugin? If so try to re-run the k3ai command...")	
+			log.Println("Something went wrong... did you check all the prerequisites to run this plugin? If so try to re-run the k3ai command...")
 		}
 		<-done
 		err = cmd.Wait()
 		if err != nil {
 			log.Fatal(err)
 		}
-  }
-  if backend == "kfp" {
-    cmd:= exec.Command("/bin/bash","-c",  "cat <<EOF | " + shellPath + k3aiKube + "  --kubeconfig="+ out + " exec  deployment/k3ai-executor -- bash -c " + execTemplateKfp )
-    cmd.Dir = shellPath
+	}
+	if backend == "kfp" {
+		cmd := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  deployment/k3ai-executor -- bash -c "+execTemplateKfp)
+		cmd.Dir = shellPath
 		r, _ := cmd.StdoutPipe()
 		cmd.Stderr = cmd.Stdout
-    done := make(chan struct{})
+		done := make(chan struct{})
 
 		scanner := bufio.NewScanner(r)
 
-    // loader.Working(msg)
-    go func() {
+		// loader.Working(msg)
+		go func() {
 			// Read line by line and process it
-      msg := "🧪	Working, please wait..."
-      fmt.Printf("\r %v", msg)
+			msg := "🧪	Working, please wait..."
+			fmt.Printf("\r %v", msg)
 			fmt.Println(" ")
 			for scanner.Scan() {
 				scanner.Text()
@@ -138,7 +136,6 @@ EOF
 		if err != nil {
 			log.Fatal(err)
 		}
-  }
-  return nil
+	}
+	return nil
 }
-

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -32,15 +32,22 @@ spec:
     spec:
       containers:
       - name: k3ai
-        image: ghcr.io/k3ai/k3ai-executor:latest
+        image: ghcr.io/k3ai/k3ai-executor:dev
         command: ["/bin/sleep", "3650d"]
 EOF
 `
 var k3aiKube = "/.tools/kubectl"
 
-func Loader(source string, target string, backend string, extras string) error {
-	var execTemplate = "\". ./run.sh -b " + backend + " -s " + source + "\" "
-	execTemplate = execTemplate + `
+
+func Loader(source string,target string,backend string, extras string, entrypoint string) error {
+	var execTemplate string
+if entrypoint == "" {
+	execTemplate ="\"/opt/k3ai-executor -b " + backend + " -s " + source  + "\" "
+	execTemplate = execTemplate+ "\nEOF"
+}
+
+var execTemplateKfp ="\"/opt/k3ai-executor -b " + backend + " -s " + source  + " -e " + entrypoint + "\" "
+execTemplateKfp = execTemplateKfp + `
 EOF
 `
 
@@ -48,19 +55,21 @@ EOF
 	out := factory.Client(name, ctype)
 	home, _ := os.UserHomeDir()
 	shellPath := home + "/.k3ai"
-	outcome, err := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+" apply  --kubeconfig="+out+" -f - "+template).Output()
-	if err != nil {
-		log.Println(err)
-	}
+  outcome,err := exec.Command("/bin/bash","-c", "cat <<EOF | " + shellPath + k3aiKube + " apply  --kubeconfig="+ out +" -f - " + template ).Output()
+  if err != nil {
+    log.Println(err)
+  }
 
-	fmt.Println(string(outcome))
+  exec.Command("/bin/bash","-c", shellPath + k3aiKube + " wait --for=condition=Ready pods --all -n default  --kubeconfig="+ out).Output()
+  fmt.Println(string(outcome))
 
-	time.Sleep(10 * time.Second)
-	outcome_new, _ := exec.Command("/bin/bash", "-c", shellPath+k3aiKube+" wait --for=condition=Ready pods --all --all-namespaces  --kubeconfig="+out).Output()
-	fmt.Println(string(outcome_new))
-	if err != nil {
-		log.Fatal(err)
-	}
+  time.Sleep(10 * time.Second)
+  
+  if backend == "mlflow" {
+	exec.Command("/bin/bash","-c",  "cat <<EOF | " + shellPath + k3aiKube + "  --kubeconfig="+ out + " exec  svc/minio-service -- bash -c \" mkdir /data/mlflow \"" ).Output()
+  }
+  exec.Command("/bin/bash","-c", shellPath + k3aiKube + " wait --for=condition=Ready pods --all -n default  --kubeconfig="+ out).Output()
+
 
 	if backend == "mlflow" {
 		cmd := exec.Command("/bin/bash", "-c", "cat <<EOF | "+shellPath+k3aiKube+"  --kubeconfig="+out+" exec  deployment/k3ai-executor -- bash -c "+execTemplate)
@@ -81,6 +90,39 @@ EOF
 			fmt.Printf("\r %v", msg)
 			fmt.Println(" ")
 			for scanner.Scan() {
+				line := scanner.Text()
+				color.Disable()
+				log.Println(line)
+			}
+			done <- struct{}{}
+		}()
+		// Start the command and check for errors
+		err := cmd.Start()
+		if err != nil {
+			log.Println("Something went wrong... did you check all the prerequisites to run this plugin? If so try to re-run the k3ai command...")	
+		}
+		<-done
+		err = cmd.Wait()
+		if err != nil {
+			log.Fatal(err)
+		}
+  }
+  if backend == "kfp" {
+    cmd:= exec.Command("/bin/bash","-c",  "cat <<EOF | " + shellPath + k3aiKube + "  --kubeconfig="+ out + " exec  deployment/k3ai-executor -- bash -c " + execTemplateKfp )
+    cmd.Dir = shellPath
+		r, _ := cmd.StdoutPipe()
+		cmd.Stderr = cmd.Stdout
+    done := make(chan struct{})
+
+		scanner := bufio.NewScanner(r)
+
+    // loader.Working(msg)
+    go func() {
+			// Read line by line and process it
+      msg := "🧪	Working, please wait..."
+      fmt.Printf("\r %v", msg)
+			fmt.Println(" ")
+			for scanner.Scan() {
 				scanner.Text()
 				color.Disable()
 			}
@@ -96,10 +138,7 @@ EOF
 		if err != nil {
 			log.Fatal(err)
 		}
-	}
-	// _,_ = exec.Command("/bin/bash","-c", "cat <<EOF | " + shellPath + k3aiKube + " delete  --kubeconfig="+ out +" -f - " + template ).Output()
-	// if err != nil {
-	//   log.Println(err)
-	// }
-	return nil
+  }
+  return nil
 }
+

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -130,8 +130,9 @@ EOF
 			fmt.Printf("\r %v", msg)
 			fmt.Println(" ")
 			for scanner.Scan() {
-				scanner.Text()
+				line := scanner.Text()
 				color.Disable()
+				log.Println(line)
 			}
 			done <- struct{}{}
 		}()


### PR DESCRIPTION
This PR address:
- #10 
- #14 
Also introduce `-x` as Extra and `-e` ad Entrypoint

Examples:
```bash
k3ai run -s https://github.com/alefesta/sample/mlflow -b mlflow -t <clustername>
k3ai run -s https://github.com/alefesta/sample/kfp -b kfp -e condition.py -t <clustername>
```
For MLFlow remains to manage the need of `boto3` in the conda.yaml file that is a requirement to run on K8s. 
This need to be addressed before merge this PR.
We may:
- try to inject boto3 in the conda.yaml file at runtime
- Force the user to fork the example first , change conda and run k3ai
The first seems more compliant with k3ai goals of `making life of user easier`